### PR TITLE
Agregar configuración de Terraform para máquinas OpenStack

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+  version     = "1.54.1"
+  constraints = "~> 1.54"
+  hashes = [
+    "h1:JC0mScAPBs1MlHeEIPMZTQGhTA5aIG3iEuKMSPpR31E=",
+    "zh:45ba84df17f94b15af7aab7007241e035dde8a5b46aeb761259d937058a80f71",
+    "zh:493b1deb7be9b600e5b1f5da2a9dfd3bce5df0c6d38090614dbe4ed05ade8441",
+    "zh:53551401fba8c1d5b27a08ee307552b84b1d0c1218f3717a4b766ec701b3e016",
+    "zh:53629bebb48ce5220f7601d776c2ac1485b6c860cb695f150fb716f5be8aa86d",
+    "zh:5a20f32cca767bef70b79bc8ecbd10fec3dc8696183e2d29631aa510947cb70d",
+    "zh:653693f630777e4aa3f410976a5169cf0f2a301516a820b3860de116054ae30a",
+    "zh:70f2d7bd5f5940f4fc3f023a01468890fbd9d704d0256bc65f7c64fb2cbcd4e4",
+    "zh:9cc22af51e5124dd5c2e0f1adefb1b08dcff3138aba9c92961cef36b1641d7aa",
+    "zh:9df45e893f215266159733dbc120809bc3d313188e121532dc6e2d10165e9899",
+    "zh:cb3e240992069cd6160f5b5cbbd50b70948f25bb337a75e780a0648461505d3f",
+    "zh:cb8343c0cf1bf5ca4d060826a8b68e3e5935b4a65974c76ac9c071c5a510e67e",
+    "zh:cc2060f93c66276dff6366b48e3a0e619874e3d939e0d2a39fc6ce10ca91232d",
+    "zh:d495b3051977018696113eded89c2cddfae0570f2adbdf7e9097c189ba41903e",
+    "zh:dfad1be943769780d5e948c06db957ce45f98b057a774964da0b82130c22f139",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # pazylara
+
+Ejemplo de configuración de Terraform para desplegar cuatro máquinas virtuales en OpenStack.
+
+## Uso
+
+1. Instala [Terraform](https://www.terraform.io/downloads.html).
+2. Crea un archivo `terraform.tfvars` con los valores de las variables requeridas:
+
+```hcl
+auth_url       = "https://openstack.example.com:5000/v3"
+user_name      = "usuario"
+password       = "contraseña"
+tenant_name    = "proyecto"
+region         = "RegionOne"
+image_name     = "ubuntu-22.04"
+flavor_name    = "m1.small"
+key_pair       = "mi-keypair"
+security_groups = ["default"]
+network_name   = "red-privada"
+```
+3. Inicializa el directorio y valida la configuración:
+
+```bash
+terraform init -backend=false
+terraform validate
+```
+4. Despliega las máquinas:
+
+```bash
+terraform apply
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.54"
+    }
+  }
+}
+
+provider "openstack" {
+  auth_url    = var.auth_url
+  user_name   = var.user_name
+  password    = var.password
+  tenant_name = var.tenant_name
+  region      = var.region
+}
+
+resource "openstack_compute_instance_v2" "vm" {
+  count = 4
+  name  = "vm-${count.index + 1}"
+
+  image_name  = var.image_name
+  flavor_name = var.flavor_name
+  key_pair    = var.key_pair
+
+  security_groups = var.security_groups
+
+  network {
+    name = var.network_name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_names" {
+  description = "Nombres de las máquinas creadas"
+  value       = [for vm in openstack_compute_instance_v2.vm : vm.name]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,50 @@
+variable "auth_url" {
+  description = "URL de autenticación de OpenStack"
+  type        = string
+}
+
+variable "user_name" {
+  description = "Usuario de OpenStack"
+  type        = string
+}
+
+variable "password" {
+  description = "Contraseña de OpenStack"
+  type        = string
+}
+
+variable "tenant_name" {
+  description = "Proyecto o tenant de OpenStack"
+  type        = string
+}
+
+variable "region" {
+  description = "Región de OpenStack"
+  type        = string
+}
+
+variable "image_name" {
+  description = "Nombre de la imagen a usar"
+  type        = string
+}
+
+variable "flavor_name" {
+  description = "Nombre del flavor de la instancia"
+  type        = string
+}
+
+variable "key_pair" {
+  description = "Nombre del par de claves a usar"
+  type        = string
+}
+
+variable "security_groups" {
+  description = "Lista de grupos de seguridad"
+  type        = list(string)
+  default     = ["default"]
+}
+
+variable "network_name" {
+  description = "Nombre de la red a la que conectarse"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Añade archivos de Terraform para desplegar cuatro instancias en OpenStack
- Documenta variables y pasos de uso en el README

## Testing
- `terraform fmt`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a72bdc83748323ae9bccd214677cb1